### PR TITLE
Set provides and conflicts for chromium

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,6 +14,8 @@ pkgdesc="A web browser built for speed, simplicity, and security, with patches f
 arch=('x86_64')
 url="https://github.com/omacom-io/omarchy-chromium"
 license=('BSD-3-Clause')
+provides=('chromium')
+conflicts=('chromium')
 depends=('gtk3' 'nss' 'alsa-lib' 'xdg-utils' 'libxss' 'libcups' 'libgcrypt'
          'ttf-liberation' 'systemd' 'dbus' 'libpulse' 'pciutils' 'libva'
          'libffi' 'desktop-file-utils' 'hicolor-icon-theme')


### PR DESCRIPTION
If you try to install `chromium` with `pacman` with this installed (or vice versa) it doesn't warn about conflicts but it fails to install due to conflicts.

So, this should explicitly say that it conflicts.