### PR TITLE
Add post_upgrade hook to clear GPU cache

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -27,6 +27,7 @@ optdepends=('pipewire: WebRTC desktop sharing under Wayland'
             'kwallet: support for storing passwords in KWallet on Plasma'
             'upower: Battery Status API support')
 options=('!lto') # Chromium adds its own flags for ThinLTO
+install=omarchy-chromium.install
 
 # NEW: Conditional source handling
 if (( _use_chromium_src )); then

--- a/PKGBUILD.arm64
+++ b/PKGBUILD.arm64
@@ -27,6 +27,7 @@ optdepends=('pipewire: WebRTC desktop sharing under Wayland'
             'kwallet: support for storing passwords in KWallet on Plasma'
             'upower: Battery Status API support')
 options=('!lto' '!strip') # Chromium adds its own flags for ThinLTO, disable strip for ARM64 cross-compilation
+install=omarchy-chromium.install
 
 # NEW: Conditional source handling
 if (( _use_chromium_src )); then

--- a/omarchy-chromium.install
+++ b/omarchy-chromium.install
@@ -1,0 +1,32 @@
+#!/usr/bin/bash
+# omarchy-chromium install script
+# This script handles post-installation and post-upgrade tasks.
+
+post_upgrade() {
+  # Clear GPU shader cache on upgrade to prevent rendering issues.
+  # Some cached shaders from older versions can cause video flickering,
+  # rendering glitches, or GPU process crashes after browser upgrades.
+  # See: https://issues.chromium.org/issues/469458278
+  echo ":: Clearing Chromium GPU cache for all users..."
+
+  for user_home in /home/*; do
+    if [ -d "$user_home" ]; then
+      # Chromium
+      rm -rf "$user_home/.config/chromium/Default/GPUCache" 2>/dev/null
+      rm -rf "$user_home/.config/chromium/ShaderCache" 2>/dev/null
+      # Also clear for additional profiles
+      rm -rf "$user_home/.config/chromium/Profile "*/GPUCache 2>/dev/null
+      rm -rf "$user_home/.config/chromium/Profile "*/ShaderCache 2>/dev/null
+    fi
+  done
+
+  # Also clear for root user if applicable
+  if [ -d /root/.config/chromium ]; then
+    rm -rf /root/.config/chromium/Default/GPUCache 2>/dev/null
+    rm -rf /root/.config/chromium/ShaderCache 2>/dev/null
+  fi
+
+  echo ":: GPU cache cleared. This prevents video rendering issues after upgrades."
+}
+
+# vim: set ts=2 sw=2 et:


### PR DESCRIPTION
## Summary

This PR adds an install script (`omarchy-chromium.install`) that clears the GPU shader cache on package upgrades.

### Problem

Cached shaders from older Chromium versions can cause rendering issues after browser upgrades:
- Video flickering (especially on NVIDIA GPUs with Wayland)
- GPU process crashes
- Rendering glitches
- WebGL failures

This is a common troubleshooting step that users have to perform manually, but package managers don't handle it automatically.

### Solution

The `post_upgrade()` function in the install script:
- Clears `GPUCache` and `ShaderCache` directories for all users
- Handles both default and additional browser profiles
- Runs automatically during `pacman -Syu` upgrades

### Files Changed

- `omarchy-chromium.install` (new) - Install script with post_upgrade hook
- `PKGBUILD` - Added `install=omarchy-chromium.install` directive
- `PKGBUILD.arm64` - Added `install=omarchy-chromium.install` directive

### Related Issues

- https://issues.chromium.org/issues/469458278
- https://github.com/basecamp/omarchy/issues/3891

### Test Plan

- [ ] Build package with `makepkg`
- [ ] Install/upgrade package
- [ ] Verify GPU cache directories are cleared
- [ ] Verify Chromium launches and videos play correctly after upgrade